### PR TITLE
Rate Limit Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ PHP Twitter is a (wrapper)class to communicate with [Twitter](http://twitter.com
 
 ## License
 
-PHP Dropbox is [BSD](http://classes.verkoyen.eu/overview/bsd) licensed.
+PHP Twitter is [BSD](http://classes.verkoyen.eu/overview/bsd) licensed.
 
 ## Documentation
 


### PR DESCRIPTION
I've added getLastRateLimitStatus() to return the rate limit information that was already present in the response headers of the latest API call. I also changed Dropbox to Twitter in the README.
