### PR TITLE
Redirect to Twitter when signin doesn't work

### DIFF
--- a/Twitter.php
+++ b/Twitter.php
@@ -2992,6 +2992,7 @@ class Twitter
     {
         header('Location: ' . self::SECURE_API_URL .
                '/oauth/authorize?oauth_token=' . $token);
+        die();
     }
 
     /**


### PR DESCRIPTION
For a vague reason the redirect to Twitter didn't work when I wanted to signin a user. The page stayed blank but accessed the method for redirect. When I added die() after the header('location') it worked. 
